### PR TITLE
`Refactor` Updating Endpoint Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bad API
 
-One day this will be like JIRA but bad.
+One day this will be a project ticketing system that is severly lacking in features when compared to other similiar products.
 
 ## The Plan
 
@@ -14,4 +14,4 @@ This API will manage:
 - Stories
 - Bugs
 
-Similar to JIRA but way lacking in features and polish.
+Similar to other project management systems, but way lacking in features and polish.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bad-api",
   "version": "0.0.1",
-  "description": "One day this will be like JIRA but bad.",
+  "description": "One day this will be a bad project management system.",
   "main": "dist/server/server.js",
   "scripts": {
     "build": "tsc && babel dist --out-dir dist",

--- a/src/controllers/project/getAll/getAllProjects.ts
+++ b/src/controllers/project/getAll/getAllProjects.ts
@@ -23,20 +23,20 @@ const getAllProjects: GetAllProjects = async (paginationData) => {
     description: project.description,
     createdOn: project.createdOn,
     createdBy:
-      project.createdBy ?
+      project.createdById && project.createdBy ?
         {
           displayName: project.createdBy.displayName,
           username: project.createdBy.username,
         }
-      : undefined,
+      : null,
     updatedOn: project.updatedOn,
     updatedBy:
-      project.updatedBy ?
+      project.updatedById && project.updatedBy ?
         {
           displayName: project.updatedBy.displayName,
           username: project.updatedBy.username,
         }
-      : undefined,
+      : null,
   }));
 };
 

--- a/src/controllers/project/getOne/index.ts
+++ b/src/controllers/project/getOne/index.ts
@@ -23,8 +23,17 @@ export const getProjectMiddleware = async (
 
 // This is used to return a requested projects details on GET /projects/:projectId
 const getOneProjectFlow = async (req: Request, res: Response) => {
-  const { id, name, description, createdOn, createdBy, updatedOn, updatedBy } =
-    req.project;
+  const {
+    id,
+    name,
+    description,
+    createdOn,
+    createdBy,
+    createdById,
+    updatedOn,
+    updatedBy,
+    updatedById,
+  } = req.project;
   return res.success('project has been successfully retrieved', {
     project: {
       id,
@@ -32,20 +41,20 @@ const getOneProjectFlow = async (req: Request, res: Response) => {
       description,
       createdOn,
       createdBy:
-        createdBy ?
+        createdById && createdBy ?
           {
             displayName: createdBy.displayName,
             username: createdBy.username,
           }
-        : undefined,
+        : null,
       updatedOn,
       updatedBy:
-        updatedBy ?
+        updatedById && updatedBy ?
           {
             displayName: updatedBy.displayName,
             username: updatedBy.username,
           }
-        : undefined,
+        : null,
       membershipCount: await req.project.countMemberships(),
     },
   });

--- a/src/controllers/project/remove/removeProject.ts
+++ b/src/controllers/project/remove/removeProject.ts
@@ -15,20 +15,20 @@ const removeProject: RemoveProject = async (project, user) => {
     description: project.description,
     createdOn: project.createdOn,
     createdBy:
-      project.createdBy ?
+      project.createdById && project.createdBy ?
         {
           username: project.createdBy.username,
           displayName: project.createdBy.displayName,
         }
-      : undefined,
+      : null,
     updatedOn: project.updatedOn,
     updatedBy:
-      project.updatedBy ?
+      project.updatedById && project.updatedBy ?
         {
           username: project.updatedBy.username,
           displayName: project.updatedBy.displayName,
         }
-      : undefined,
+      : null,
     deletedOn: project.deletedOn,
     deletedBy: {
       username: user.username,

--- a/src/controllers/project/update/updateProject.ts
+++ b/src/controllers/project/update/updateProject.ts
@@ -29,12 +29,12 @@ const updateProject: UpdateProject = async (user, project, name, description) =>
     description: project.description,
     createdOn: project.createdOn,
     createdBy:
-      project.createdBy ?
+      project.createdById && project.createdBy ?
         {
           username: project.createdBy.username,
           displayName: project.createdBy.displayName,
         }
-      : undefined,
+      : null,
     updatedOn: project.updatedOn,
     updatedBy: {
       username: user.username,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -67,7 +67,7 @@ initializeDatabaseConnection().then(() => {
   // Start the server.
   server.listen(PORT, () => {
     console.log(
-      'Bad JIRA listening on port %s using %s protocol',
+      'Bad API listening on port %s using %s protocol',
       PORT,
       useHttps ? 'https' : 'http',
     );

--- a/src/server/types/index.ts
+++ b/src/server/types/index.ts
@@ -12,8 +12,8 @@ export interface ProjectData {
   description?: string | null;
   createdOn: Date;
   updatedOn?: Date | null;
-  deletedOn?: Date;
-  createdBy?: Omit<UserData, 'createdOn' | 'updatedOn'>;
-  updatedBy?: Omit<UserData, 'createdOn' | 'updatedOn'>;
-  deletedBy?: Omit<UserData, 'createdOn' | 'updatedOn'>;
+  deletedOn?: Date | null;
+  createdBy: Omit<UserData, 'createdOn' | 'updatedOn'> | null;
+  updatedBy?: Omit<UserData, 'createdOn' | 'updatedOn'> | null;
+  deletedBy?: Omit<UserData, 'createdOn' | 'updatedOn'> | null;
 }

--- a/test/auth/authenticateToken.test.ts
+++ b/test/auth/authenticateToken.test.ts
@@ -149,10 +149,12 @@ describe('Authenticate AuthToken', () => {
 
           const { message, user } = res.body;
           expect(message).toBe('user successfully authenticated via token');
-          expect(user).toBeTruthy();
-          expect(user.username).toBe(testUser.username);
-          expect(user.displayName).toBe(testUser.displayName);
-          expect(user.createdOn).toBe(testUser.createdOn.toISOString());
+          expect(user).toEqual({
+            username: testUser.username,
+            displayName: testUser.displayName,
+            createdOn: testUser.createdOn.toISOString(),
+            updatedOn: null,
+          });
           done();
         });
     });

--- a/test/auth/generateToken.test.ts
+++ b/test/auth/generateToken.test.ts
@@ -99,10 +99,12 @@ describe('Generate AuthToken', () => {
           const { message, user } = res.body;
           expect(message).toBe('user successfully authenticated');
           expect(res.headers['x-auth-token']).toBeTruthy();
-          expect(user).toBeTruthy();
-          expect(user.username).toBe(testUser.username);
-          expect(user.displayName).toBe(testUser.displayName);
-          expect(user.createdOn).toBe(testUser.createdOn.toISOString());
+          expect(user).toEqual({
+            username: testUser.username,
+            displayName: testUser.displayName,
+            createdOn: testUser.createdOn.toISOString(),
+            updatedOn: null,
+          });
           done();
         });
     });

--- a/test/project/getAllProjects.test.ts
+++ b/test/project/getAllProjects.test.ts
@@ -11,7 +11,8 @@ describe('Project GetAll', () => {
     let authenticatedUser: User;
     let testUser1: User;
     let testUser2: User;
-    let testProject: Project;
+    let sampleProject1: Project;
+    let sampleProject2: Project;
     let authToken: string;
 
     beforeAll(async () => {
@@ -39,20 +40,20 @@ describe('Project GetAll', () => {
         'test project 4',
         'project4 was generated via automated testing.',
       );
-      testProject = await testHelper.createTestProject(
+      sampleProject1 = await testHelper.createTestProject(
         testUser1,
         'test project 5',
         'project5 was generated via automated testing.',
       );
-      await testHelper.createTestProject(
+      sampleProject2 = await testHelper.createTestProject(
         testUser2,
         'test project 6',
         'project6 was generated via automated testing.',
       );
 
-      testProject.updatedById = testUser2.id;
-      testProject.updatedOn = new Date();
-      await testProject.save();
+      sampleProject1.updatedById = testUser2.id;
+      sampleProject1.updatedOn = new Date();
+      await sampleProject1.save();
 
       const inactiveProject = await testHelper.createTestProject(authenticatedUser);
       inactiveProject.isActive = false;
@@ -88,30 +89,42 @@ describe('Project GetAll', () => {
             return done(err);
           }
 
-          const { message, projects, page, itemsPerPage, totalPages, totalItems } =
-            res.body;
+          const { message, ...projectListData } = res.body;
           expect(message).toBe('project list has been successfully retrieved');
-          expect(page).toBe(3);
-          expect(itemsPerPage).toBe(2);
-          expect(totalPages).toBe(3);
-          expect(totalItems).toBe(6);
-          expect(projects).toBeTruthy();
-          expect(projects.length).toBe(2);
-          const project = projects[0];
-          expect(project.id).toBe(testProject.id);
-          expect(project.name).toBe(testProject.name);
-          expect(project.description).toBe(testProject.description);
-
-          expect(project.createdOn).toBe(testProject.createdOn.toISOString());
-          expect(project.createdBy).toEqual({
-            username: testUser1.username,
-            displayName: testUser1.displayName,
-          });
-
-          expect(project.updatedOn).toBe(testProject.updatedOn?.toISOString());
-          expect(project.updatedBy).toEqual({
-            username: testUser2.username,
-            displayName: testUser2.displayName,
+          expect(projectListData).toEqual({
+            page: 3,
+            itemsPerPage: 2,
+            totalPages: 3,
+            totalItems: 6,
+            projects: [
+              {
+                id: sampleProject1.id,
+                name: sampleProject1.name,
+                description: sampleProject1.description,
+                createdOn: sampleProject1.createdOn.toISOString(),
+                createdBy: {
+                  username: testUser1.username,
+                  displayName: testUser1.displayName,
+                },
+                updatedOn: sampleProject1.updatedOn?.toISOString(),
+                updatedBy: {
+                  username: testUser2.username,
+                  displayName: testUser2.displayName,
+                },
+              },
+              {
+                id: sampleProject2.id,
+                name: sampleProject2.name,
+                description: sampleProject2.description,
+                createdOn: sampleProject2.createdOn.toISOString(),
+                createdBy: {
+                  username: testUser2.username,
+                  displayName: testUser2.displayName,
+                },
+                updatedOn: null,
+                updatedBy: null,
+              },
+            ],
           });
 
           done();

--- a/test/project/getOneProject.test.ts
+++ b/test/project/getOneProject.test.ts
@@ -110,24 +110,23 @@ describe('Project GetOne', () => {
 
           const { message, project } = res.body;
           expect(message).toBe('project has been successfully retrieved');
-          expect(project).toBeTruthy();
-          expect(project.id).toBe(testProject.id);
-          expect(project.name).toBe(testProject.name);
-          expect(project.description).toBe(testProject.description);
-
-          expect(project.createdOn).toBe(testProject.createdOn.toISOString());
-          expect(project.createdBy).toEqual({
-            username: testUser1.username,
-            displayName: testUser1.displayName,
+          expect(project).toEqual({
+            id: testProject.id,
+            name: testProject.name,
+            description: testProject.description,
+            createdOn: testProject.createdOn.toISOString(),
+            createdBy: {
+              username: testUser1.username,
+              displayName: testUser1.displayName,
+            },
+            updatedOn: testProject.updatedOn?.toISOString(),
+            updatedBy: {
+              username: testUser2.username,
+              displayName: testUser2.displayName,
+            },
+            membershipCount: 2,
           });
 
-          expect(project.updatedOn).toBe(testProject.updatedOn?.toISOString());
-          expect(project.updatedBy).toEqual({
-            username: testUser2.username,
-            displayName: testUser2.displayName,
-          });
-
-          expect(project.membershipCount).toBe(2);
           done();
         });
     });

--- a/test/project/removeProject.test.ts
+++ b/test/project/removeProject.test.ts
@@ -190,38 +190,34 @@ describe('Project Remove', () => {
             return done(err);
           }
 
+          // Ensure the project was actually removed.
+          const removedTestProject = await Project.findOne({
+            where: { id: testProject.id, isActive: false },
+          });
+          if (!removedTestProject) {
+            return done('removed project was not found in database');
+          }
+
           const { message, project } = res.body;
           expect(message).toBe('project has been successfully removed');
-          expect(project).toBeTruthy();
-          expect(project.id).toBe(testProject.id);
-          expect(project.name).toBe(testProject.name);
-          expect(project.description).toBe(testProject.description);
-
-          expect(project.createdOn).toBe(testProject.createdOn.toISOString());
-          expect(project.createdBy).toBeTruthy();
-          expect(project.createdBy).toEqual({
-            username: authenticatedUser.username,
-            displayName: authenticatedUser.displayName,
+          expect(project).toEqual({
+            id: testProject.id,
+            name: testProject.name,
+            description: testProject.description,
+            createdOn: testProject.createdOn.toISOString(),
+            createdBy: {
+              username: authenticatedUser.username,
+              displayName: authenticatedUser.displayName,
+            },
+            updatedOn: null,
+            updatedBy: null,
+            deletedOn: removedTestProject.deletedOn?.toISOString(),
+            deletedBy: {
+              username: authenticatedUser.username,
+              displayName: authenticatedUser.displayName,
+            },
           });
-
-          expect(project.updatedOn).toBeFalsy();
-          expect(project.updatedBy).toEqual({
-            username: null,
-            displayName: null,
-          });
-
-          expect(project.deletedOn).toBeTruthy();
-          expect(project.deletedBy).toEqual({
-            username: authenticatedUser.username,
-            displayName: authenticatedUser.displayName,
-          });
-
-          // Ensure the user is actually removed.
-          const removedTestProject = await Project.findOne({
-            where: { id: testProject.id },
-          });
-          expect(project.deletedOn).toBe(removedTestProject?.deletedOn?.toISOString());
-          expect(removedTestProject?.isActive).toBe(false);
+          expect(removedTestProject.deletedById).toBe(authenticatedUser.id);
           done();
         });
     });

--- a/test/user/getOneUser.test.ts
+++ b/test/user/getOneUser.test.ts
@@ -16,12 +16,13 @@ describe('User GetOne', () => {
     beforeAll(async () => {
       authenticatedUser = await testHelper.createTestUser();
       testUser = await testHelper.createTestUser();
-      authToken = testHelper.generateToken(authenticatedUser);
 
       inactiveUser = await testHelper.createTestUser();
       inactiveUser.isActive = false;
       inactiveUser.deletedOn = new Date();
       await inactiveUser.save();
+
+      authToken = testHelper.generateToken(authenticatedUser);
     });
 
     beforeEach(() => {
@@ -79,10 +80,11 @@ describe('User GetOne', () => {
 
           const { message, user } = res.body;
           expect(message).toBe('user has been successfully retrieved');
-          expect(user).toBeTruthy();
-          expect(user.username).toBe(testUser.username);
-          expect(user.displayName).toBe(testUser.displayName);
-          expect(user.createdOn).toBe(testUser.createdOn.toISOString());
+          expect(user).toEqual({
+            username: testUser.username,
+            displayName: testUser.displayName,
+            createdOn: testUser.createdOn.toISOString(),
+          });
           done();
         });
     });


### PR DESCRIPTION
This PR updates existing endpoint tests to use `toEqual` when comparing data returned in the response body.

toEqual allows us to check the entire response data, instead of select fields, which gives us a better picture of how the entire response looks.