### PR TITLE
`Refactor` Fixing Model Associations

### DIFF
--- a/src/controllers/project/getAll/getAllProjects.ts
+++ b/src/controllers/project/getAll/getAllProjects.ts
@@ -12,8 +12,8 @@ const getAllProjects: GetAllProjects = async (paginationData) => {
     offset: pageOffset,
     order: [['createdOn', 'ASC']],
     include: [
-      { model: User.scope('publicAttributes'), as: 'createdBy' },
-      { model: User.scope('publicAttributes'), as: 'updatedBy' },
+      { model: User.scope('publicAttributes'), as: 'createdBy', required: false },
+      { model: User.scope('publicAttributes'), as: 'updatedBy', required: false },
     ],
   });
 

--- a/src/controllers/project/getOne/getOneProject.ts
+++ b/src/controllers/project/getOne/getOneProject.ts
@@ -6,8 +6,8 @@ type GetOneProject = (projectId: string, authUser: User) => Promise<Project>;
 
 const getOneProject: GetOneProject = async (projectId, authUser) => {
   let include: Includeable[] = [
-    { model: User.scope('publicAttributes'), as: 'createdBy' },
-    { model: User.scope('publicAttributes'), as: 'updatedBy' },
+    { model: User.scope('publicAttributes'), as: 'createdBy', required: false },
+    { model: User.scope('publicAttributes'), as: 'updatedBy', required: false },
   ];
   if (authUser) {
     include = include.concat({

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,48 +21,64 @@ export const initializeModels = (sequelize: Sequelize) => {
   /*  Sequelize is weird. These associations need to be done outside of the model files
    *  and after model initialization because of our code structure.
    */
-  // Project associations
+
+  // Project -> User associations: createdBy
   User.hasMany(Project, { as: 'createdProjects', foreignKey: 'createdById' });
-  Project.belongsTo(User, { as: 'createdBy', foreignKey: 'createdById' });
+  User.hasOne(Project, { as: 'createdProject', foreignKey: 'createdById' });
+  Project.belongsTo(User, { as: 'createdBy' });
 
+  // Project -> User associations: updatedBy
   User.hasMany(Project, { as: 'updatedProjects', foreignKey: 'updatedById' });
-  Project.belongsTo(User, { as: 'updatedBy', foreignKey: 'updatedById' });
+  User.hasOne(Project, { as: 'updatedProject', foreignKey: 'updatedById' });
+  Project.belongsTo(User, { as: 'updatedBy' });
 
+  // Project -> User associations: deletedBy
   User.hasMany(Project, { as: 'deletedProjects', foreignKey: 'deletedById' });
-  Project.belongsTo(User, { as: 'deletedBy', foreignKey: 'deletedById' });
+  User.hasOne(Project, { as: 'deletedProject', foreignKey: 'deletedById' });
+  Project.belongsTo(User, { as: 'deletedBy' });
 
-  // Membership associations
+  // Membership -> User associations: createdBy
+  User.hasMany(Membership, { as: 'createdMemberships', foreignKey: 'createdById' });
+  User.hasOne(Membership, { as: 'createdMembership', foreignKey: 'createdById' });
+  Membership.belongsTo(User, { as: 'createdBy' });
+
+  // Membership -> User associations: updatedBy
+  User.hasMany(Membership, { as: 'updatedMemberships', foreignKey: 'updatedById' });
+  User.hasOne(Membership, { as: 'updatedMembership', foreignKey: 'updatedById' });
+  Membership.belongsTo(User, { as: 'updatedBy' });
+
+  // Membership -> User associations: memberships
   User.hasMany(Membership, {
     as: 'memberships',
     foreignKey: 'userId',
     onDelete: 'CASCADE',
   });
-  Membership.belongsTo(User, {
+  User.hasOne(Membership, {
     foreignKey: 'userId',
+    onDelete: 'CASCADE',
+  });
+  Membership.belongsTo(User, {
     as: 'user',
   });
 
+  // Membership -> User associations: memberships
   Project.hasMany(Membership, {
     as: 'memberships',
     foreignKey: 'projectId',
     onDelete: 'CASCADE',
   });
-  Membership.belongsTo(Project, {
+  Project.hasOne(Membership, {
     foreignKey: 'projectId',
-    as: 'project',
+    onDelete: 'CASCADE',
   });
-
   Project.hasOne(Membership, {
     as: 'authUserMembership',
     foreignKey: 'projectId',
     onDelete: 'CASCADE',
   });
-
-  User.hasMany(Membership, { as: 'createdMemberships', foreignKey: 'createdById' });
-  Membership.belongsTo(User, { as: 'createdBy', foreignKey: 'createdById' });
-
-  User.hasMany(Membership, { as: 'updatedMemberships', foreignKey: 'updatedById' });
-  Membership.belongsTo(User, { as: 'updatedBy', foreignKey: 'updatedById' });
+  Membership.belongsTo(Project, {
+    as: 'project',
+  });
 };
 
 export const initializeModelsAndSync = async (sequelize: Sequelize) => {

--- a/src/models/membership/membership.ts
+++ b/src/models/membership/membership.ts
@@ -6,8 +6,8 @@ import {
   CreationOptional,
   DataTypes,
   ForeignKey,
-  BelongsToGetAssociationMixin,
   NonAttribute,
+  BelongsToGetAssociationMixin,
 } from 'sequelize';
 import User from 'src/models/user/user';
 import Project from 'src/models/project/project';
@@ -17,26 +17,28 @@ class Membership extends Model<
   InferCreationAttributes<Membership>
 > {
   declare id: CreationOptional<string>;
-  // Can add members, can add stories/epics/bugs, can delete project
   declare isProjectAdmin: CreationOptional<boolean>;
-  // Can add members, can add stories/epics/bugs
   declare isProjectManager: CreationOptional<boolean>;
 
+  // User associations - BelongsTo
+  declare getCreatedBy: BelongsToGetAssociationMixin<User | null>;
   declare createdById: ForeignKey<User['id']>;
-  declare createdBy: NonAttribute<User>;
+  declare createdBy: NonAttribute<User | null>;
   declare createdOn: CreationOptional<Date>;
 
-  declare updatedById: ForeignKey<User['id']> | null;
-  declare updatedBy: NonAttribute<User> | null;
-  declare updatedOn: CreationOptional<Date> | null;
+  declare getUpdatedBy: BelongsToGetAssociationMixin<User | null>;
+  declare updatedById: ForeignKey<User['id'] | null>;
+  declare updatedBy: NonAttribute<User | null>;
+  declare updatedOn: CreationOptional<Date | null>;
 
+  declare getUser: BelongsToGetAssociationMixin<User>;
   declare userId: ForeignKey<User['id']>;
   declare user: NonAttribute<User>;
-  declare getUser: BelongsToGetAssociationMixin<User>;
 
+  // Project associations - BelongsTo
+  declare getProject: BelongsToGetAssociationMixin<Project>;
   declare projectId: ForeignKey<Project['id']>;
   declare project: NonAttribute<Project>;
-  declare getProject: BelongsToGetAssociationMixin<Project>;
 }
 
 export const initializeMembership = (sequelize: Sequelize) => {

--- a/src/models/project/project.ts
+++ b/src/models/project/project.ts
@@ -5,11 +5,13 @@ import {
   InferCreationAttributes,
   CreationOptional,
   DataTypes,
-  HasManyCreateAssociationMixin,
-  HasManyGetAssociationsMixin,
-  HasManyCountAssociationsMixin,
   ForeignKey,
   NonAttribute,
+  BelongsToGetAssociationMixin,
+  HasManyGetAssociationsMixin,
+  HasManyCountAssociationsMixin,
+  HasManyCreateAssociationMixin,
+  HasOneGetAssociationMixin,
 } from 'sequelize';
 import User from 'src/models/user/user';
 import Membership from 'src/models/membership/membership';
@@ -18,24 +20,32 @@ class Project extends Model<InferAttributes<Project>, InferCreationAttributes<Pr
   declare id: CreationOptional<string>;
   declare isActive: CreationOptional<boolean>;
   declare name: string;
-  declare description: CreationOptional<string> | null;
+  declare description: CreationOptional<string | null>;
 
+  // User associations - BelongsTo
+  declare getCreatedBy: BelongsToGetAssociationMixin<User | null>;
+  declare createdById: ForeignKey<User['id']>;
+  declare createdBy: NonAttribute<User | null>;
+  declare createdOn: CreationOptional<Date>;
+
+  declare getUpdatedBy: BelongsToGetAssociationMixin<User | null>;
+  declare updatedById: ForeignKey<User['id'] | null>;
+  declare updatedBy: NonAttribute<User | null>;
+  declare updatedOn: CreationOptional<Date | null>;
+
+  declare getDeletedBy: BelongsToGetAssociationMixin<User | null>;
+  declare deletedById: ForeignKey<User['id'] | null>;
+  declare deletedBy: NonAttribute<User | null>;
+  declare deletedOn: CreationOptional<Date | null>;
+
+  // Membership associations - HasMany
   declare createMembership: HasManyCreateAssociationMixin<Membership>;
   declare getMemberships: HasManyGetAssociationsMixin<Membership>;
   declare countMemberships: HasManyCountAssociationsMixin;
-  declare authUserMembership: NonAttribute<Membership> | null;
 
-  declare createdById: ForeignKey<User['id']>;
-  declare createdBy: NonAttribute<User>;
-  declare createdOn: CreationOptional<Date>;
-
-  declare updatedById: ForeignKey<User['id']> | null;
-  declare updatedBy: NonAttribute<User> | null;
-  declare updatedOn: CreationOptional<Date> | null;
-
-  declare deletedById: ForeignKey<User['id']> | null;
-  declare deletedBy: NonAttribute<User> | null;
-  declare deletedOn: CreationOptional<Date> | null;
+  // Membership associations - HasOne
+  declare getMembership: HasOneGetAssociationMixin<Membership | null>;
+  declare authUserMembership: NonAttribute<Membership | null>;
 }
 
 export const initializeProject = (sequelize: Sequelize) => {

--- a/src/models/user/user.ts
+++ b/src/models/user/user.ts
@@ -9,7 +9,10 @@ import {
   DataTypes,
   NonAttribute,
   HasManyGetAssociationsMixin,
+  HasManyCountAssociationsMixin,
+  HasOneGetAssociationMixin,
 } from 'sequelize';
+import Project from 'src/models/project/project';
 import Membership from 'src/models/membership/membership';
 
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
@@ -20,10 +23,34 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
   declare hash: string;
   declare apiKey: CreationOptional<string>;
   declare createdOn: CreationOptional<Date>;
-  declare updatedOn: CreationOptional<Date> | null;
-  declare deletedOn: CreationOptional<Date> | null;
+  declare updatedOn: CreationOptional<Date | null>;
+  declare deletedOn: CreationOptional<Date | null>;
 
+  // Project associations - HasMany
+  declare getCreatedProjects: HasManyGetAssociationsMixin<Project>;
+  declare countCreatedProjects: HasManyCountAssociationsMixin;
+  declare getUpdatedProjects: HasManyGetAssociationsMixin<Project>;
+  declare countUpdatedProjects: HasManyCountAssociationsMixin;
+  declare getDeletedProjects: HasManyGetAssociationsMixin<Project>;
+  declare countDeletedProjects: HasManyCountAssociationsMixin;
+
+  // Project associations - HasOne
+  declare getCreatedProject: HasOneGetAssociationMixin<Project | null>;
+  declare getUpdatedProject: HasOneGetAssociationMixin<Project | null>;
+  declare getDeletedProject: HasOneGetAssociationMixin<Project | null>;
+
+  // Membership associations - HasMany
+  declare getCreatedMemberships: HasManyGetAssociationsMixin<Membership>;
+  declare countCreatedMemberships: HasManyCountAssociationsMixin;
+  declare getUpdatedMemberships: HasManyGetAssociationsMixin<Membership>;
+  declare countUpdatedMemberships: HasManyCountAssociationsMixin;
   declare getMemberships: HasManyGetAssociationsMixin<Membership>;
+  declare countMemberships: HasManyCountAssociationsMixin;
+
+  // Membership associations - HasOne
+  declare getCreatedMembership: HasOneGetAssociationMixin<Membership | null>;
+  declare getUpdatedMembership: HasOneGetAssociationMixin<Membership | null>;
+  declare getMembership: HasOneGetAssociationMixin<Membership | null>;
 
   static generateHash(password: string): NonAttribute<string> {
     return bcrypt.hashSync(password, SALT_ROUNDS);


### PR DESCRIPTION
This PR reworks the Sequelize model associations and also adds more association methods to each model. I also updated `include` queries to not be required when fetching associations.