### PR TITLE
`Feature` Project Permissions

### DIFF
--- a/src/controllers/auth/authorizeMembershipAction/authorizeMembershipRemove.ts
+++ b/src/controllers/auth/authorizeMembershipAction/authorizeMembershipRemove.ts
@@ -1,17 +1,15 @@
-import { Membership, Project } from 'src/models';
+import { Project } from 'src/models';
 import { AuthorizationError } from 'src/server/utils/errors';
 
 type AuthorizeMembershipRemove = (
   authUserMembership: Project['authUserMembership'],
-  requestedMembership: Membership,
+  requestedMembershipIsAdmin: boolean,
 ) => void;
 
 const authorizeMembershipRemove: AuthorizeMembershipRemove = (
   authUserMembership,
-  requestedMembership,
+  requestedMembershipIsAdmin,
 ) => {
-  const requestedMembershipIsAdmin = requestedMembership.isProjectAdmin === true;
-
   if (
     requestedMembershipIsAdmin &&
     (!authUserMembership || !authUserMembership.isProjectAdmin)

--- a/src/controllers/auth/authorizeMembershipAction/authorizeMembershipUpdate.ts
+++ b/src/controllers/auth/authorizeMembershipAction/authorizeMembershipUpdate.ts
@@ -1,20 +1,19 @@
-import { Membership, Project } from 'src/models';
+import { Project } from 'src/models';
 import { AuthorizationError } from 'src/server/utils/errors';
 
 type AuthorizeMembershipUpdate = (
   authUserMembership: Project['authUserMembership'],
-  requestedMembership: Membership,
+  requestedMembershipIsAdmin: boolean,
   isProjectAdminInputValue: unknown,
 ) => void;
 
 const authorizeMembershipUpdate: AuthorizeMembershipUpdate = (
   authUserMembership,
-  requestedMembership,
+  requestedMembershipIsAdmin,
   isProjectAdminInputValue,
 ) => {
   const isAddingAdminPrivileges = isProjectAdminInputValue === true;
   const isRemovingAdminPrivileges = isProjectAdminInputValue === false;
-  const requestedMembershipIsAdmin = requestedMembership.isProjectAdmin === true;
 
   // If the existing membership is NOT admin, you need to be admin to add it.
   if (

--- a/src/controllers/auth/authorizeMembershipAction/index.ts
+++ b/src/controllers/auth/authorizeMembershipAction/index.ts
@@ -16,14 +16,17 @@ const authorizeMembershipActionFlow = (action: AuthorizationAction) => {
       if (action === AuthorizationAction.UPDATE) {
         authorizeMembershipUpdate(
           req.project.authUserMembership,
-          req.membership,
+          req.membership.isProjectAdmin,
           req.body.isProjectAdmin,
         );
         return next();
       }
 
       if (action === AuthorizationAction.DELETE) {
-        authorizeMembershipRemove(req.project.authUserMembership, req.membership);
+        authorizeMembershipRemove(
+          req.project.authUserMembership,
+          req.membership.isProjectAdmin,
+        );
         return next();
       }
 

--- a/src/controllers/auth/getProjectPermissions/index.ts
+++ b/src/controllers/auth/getProjectPermissions/index.ts
@@ -1,0 +1,162 @@
+import { Request, Response } from 'express';
+import authorizeProjectRemove from 'src/controllers/auth/authorizeProjectAction/authorizeProjectRemove';
+import authorizeProjectUpdate from 'src/controllers/auth/authorizeProjectAction/authorizeProjectUpdate';
+import authorizeMembershipCreate from 'src/controllers/auth/authorizeMembershipAction/authorizeMembershipCreate';
+import authorizeStatusCreate from 'src/controllers/auth/authorizeStatusAction/authorizeStatusCreate';
+import authorizeStatusUpdate from 'src/controllers/auth/authorizeStatusAction/authorizeStatusUpdate';
+import authorizeStatusRemove from 'src/controllers/auth/authorizeStatusAction/authorizeStatusRemove';
+import authorizeStoryCreate from 'src/controllers/auth/authorizeStoryAction/authorizeStoryCreate';
+import authorizeStoryUpdate from 'src/controllers/auth/authorizeStoryAction/authorizeStoryUpdate';
+import authorizeStoryRead from 'src/controllers/auth/authorizeStoryAction/authorizeStoryRead';
+import authorizeStoryRemove from 'src/controllers/auth/authorizeStoryAction/authorizeStoryRemove';
+import authorizeMembershipUpdate from 'src/controllers/auth/authorizeMembershipAction/authorizeMembershipUpdate';
+import authorizeMembershipRemove from 'src/controllers/auth/authorizeMembershipAction/authorizeMembershipRemove';
+
+const getProjectPermissions = (req: Request, res: Response) => {
+  const { authUserMembership } = req.project;
+  let canRemoveProject: boolean;
+  let canUpdateProject: boolean;
+
+  let canCreateAdminMembership: boolean;
+  let canCreateMembership: boolean;
+  let canUpdateAdminMembership: boolean;
+  let canUpdateMembership: boolean;
+  let canRemoveAdminMembership: boolean;
+  let canRemoveMembership: boolean;
+
+  let canCreateStatus: boolean;
+  let canUpdateStatus: boolean;
+  let canRemoveStatus: boolean;
+
+  let canCreateStory: boolean;
+  let canUpdateStory: boolean;
+  let canRemoveStory: boolean;
+  let canReadStory: boolean;
+
+  try {
+    authorizeProjectRemove(authUserMembership);
+    canRemoveProject = true;
+  } catch {
+    canRemoveProject = false;
+  }
+
+  try {
+    authorizeProjectUpdate(authUserMembership);
+    canUpdateProject = true;
+  } catch {
+    canUpdateProject = false;
+  }
+
+  try {
+    authorizeMembershipCreate(authUserMembership, true);
+    canCreateAdminMembership = true;
+  } catch {
+    canCreateAdminMembership = false;
+  }
+
+  try {
+    authorizeMembershipUpdate(authUserMembership, true, false);
+    canUpdateAdminMembership = true;
+  } catch {
+    canUpdateAdminMembership = false;
+  }
+
+  try {
+    authorizeMembershipRemove(authUserMembership, true);
+    canRemoveAdminMembership = true;
+  } catch {
+    canRemoveAdminMembership = false;
+  }
+
+  try {
+    authorizeMembershipCreate(authUserMembership, false);
+    canCreateMembership = true;
+  } catch {
+    canCreateMembership = false;
+  }
+
+  try {
+    authorizeMembershipUpdate(authUserMembership, false, null);
+    canUpdateMembership = true;
+  } catch {
+    canUpdateMembership = false;
+  }
+
+  try {
+    authorizeMembershipRemove(authUserMembership, false);
+    canRemoveMembership = true;
+  } catch {
+    canRemoveMembership = false;
+  }
+
+  try {
+    authorizeStatusCreate(authUserMembership);
+    canCreateStatus = true;
+  } catch {
+    canCreateStatus = false;
+  }
+
+  try {
+    authorizeStatusUpdate(authUserMembership);
+    canUpdateStatus = true;
+  } catch {
+    canUpdateStatus = false;
+  }
+
+  try {
+    authorizeStatusRemove(authUserMembership);
+    canRemoveStatus = true;
+  } catch {
+    canRemoveStatus = false;
+  }
+
+  try {
+    authorizeStoryCreate(authUserMembership);
+    canCreateStory = true;
+  } catch {
+    canCreateStory = false;
+  }
+
+  try {
+    authorizeStoryUpdate(authUserMembership);
+    canUpdateStory = true;
+  } catch {
+    canUpdateStory = false;
+  }
+
+  try {
+    authorizeStoryRemove(authUserMembership);
+    canRemoveStory = true;
+  } catch {
+    canRemoveStory = false;
+  }
+
+  try {
+    authorizeStoryRead(authUserMembership);
+    canReadStory = true;
+  } catch {
+    canReadStory = false;
+  }
+
+  return res.success('project permissions successfully retrieved', {
+    permissions: {
+      canRemoveProject,
+      canUpdateProject,
+      canCreateAdminMembership,
+      canCreateMembership,
+      canUpdateAdminMembership,
+      canUpdateMembership,
+      canRemoveAdminMembership,
+      canRemoveMembership,
+      canCreateStatus,
+      canUpdateStatus,
+      canRemoveStatus,
+      canCreateStory,
+      canUpdateStory,
+      canRemoveStory,
+      canReadStory,
+    },
+  });
+};
+
+export default getProjectPermissions;

--- a/src/controllers/auth/index.ts
+++ b/src/controllers/auth/index.ts
@@ -6,6 +6,7 @@ import { default as authorizeProjectAction } from './authorizeProjectAction';
 import { default as authorizeMembershipAction } from './authorizeMembershipAction';
 import { default as authorizeStatusAction } from './authorizeStatusAction';
 import { default as authorizeStoryAction } from './authorizeStoryAction';
+import { default as getProjectPermissions } from './getProjectPermissions';
 
 export default {
   generateToken,
@@ -16,4 +17,5 @@ export default {
   authorizeMembershipAction,
   authorizeStatusAction,
   authorizeStoryAction,
+  getProjectPermissions,
 };

--- a/src/routes/project.ts
+++ b/src/routes/project.ts
@@ -21,6 +21,11 @@ const configureProjectRoutes = (router: Router) => {
       AuthController.authorizeProjectAction(AuthorizationAction.DELETE),
       ProjectController.remove,
     );
+
+  router
+    .route('/projects/:projectId/permissions')
+    .all(AuthController.authenticateToken, ProjectController.getProjectMiddleware)
+    .get(AuthController.getProjectPermissions);
 };
 
 export default configureProjectRoutes;

--- a/test/project/getProjectPermissions.test.ts
+++ b/test/project/getProjectPermissions.test.ts
@@ -1,0 +1,289 @@
+import { TestHelper } from '../utils';
+import { ErrorTypes } from '../../src/server/utils/errors';
+import request from 'supertest';
+import { User, Project } from '../../src/models';
+const testHelper = new TestHelper();
+const serverUrl = testHelper.getServerUrl();
+let apiRoute = '/projects/:projectId/permissions';
+
+describe('Project GetProjectPermissions', () => {
+  describe(`GET ${apiRoute}`, () => {
+    let testProject: Project;
+    let inactiveProject: Project;
+
+    let adminUser: User;
+    let managerUser: User;
+    let developerUser: User;
+    let viewerUser: User;
+    let nonMemberUser: User;
+
+    let adminAuthToken: string;
+    let managerAuthToken: string;
+    let developerAuthToken: string;
+    let viewerAuthToken: string;
+    let nonMemberAuthToken: string;
+
+    beforeAll(async () => {
+      adminUser = await testHelper.createTestUser();
+      managerUser = await testHelper.createTestUser();
+      developerUser = await testHelper.createTestUser();
+      viewerUser = await testHelper.createTestUser();
+      nonMemberUser = await testHelper.createTestUser();
+
+      testProject = await testHelper.createTestProject(
+        adminUser,
+        'unit test project',
+        'this project was generated via automated testing.',
+      );
+
+      await testProject.createMembership({
+        userId: managerUser.id,
+        isProjectManager: true,
+        createdById: adminUser.id,
+      });
+
+      await testProject.createMembership({
+        userId: developerUser.id,
+        isProjectDeveloper: true,
+        createdById: adminUser.id,
+      });
+
+      await testProject.createMembership({
+        userId: viewerUser.id,
+        createdById: adminUser.id,
+      });
+
+      inactiveProject = await testHelper.createTestProject(adminUser);
+      inactiveProject.deletedOn = new Date();
+      inactiveProject.deletedById = adminUser.id;
+      inactiveProject.isActive = false;
+      await inactiveProject.save();
+
+      adminAuthToken = testHelper.generateToken(adminUser);
+      managerAuthToken = testHelper.generateToken(managerUser);
+      developerAuthToken = testHelper.generateToken(developerUser);
+      viewerAuthToken = testHelper.generateToken(viewerUser);
+      nonMemberAuthToken = testHelper.generateToken(nonMemberUser);
+    });
+
+    afterAll(async () => {
+      await testHelper.removeTestData();
+    });
+
+    beforeEach(() => {
+      apiRoute = `/projects/${testProject.id}/permissions`;
+    });
+
+    it('should reject requests when x-auth-token is missing', (done) => {
+      request(serverUrl).get(apiRoute).expect(
+        400,
+        {
+          error: 'x-auth-token header is missing from input',
+          errorType: ErrorTypes.VALIDATION,
+        },
+        done,
+      );
+    });
+
+    it('should reject requests when projectId is not a valid UUID', (done) => {
+      apiRoute = '/projects/somethingInvalid/permissions';
+      request(serverUrl).get(apiRoute).set('x-auth-token', adminAuthToken).expect(
+        400,
+        {
+          error: 'requested project id is not valid',
+          errorType: ErrorTypes.VALIDATION,
+        },
+        done,
+      );
+    });
+
+    it('should reject requests when the requested project does not exist', (done) => {
+      apiRoute = `/projects/${testHelper.generateUUID()}/permissions`;
+      request(serverUrl).get(apiRoute).set('x-auth-token', adminAuthToken).expect(
+        404,
+        {
+          error: 'requested project not found',
+          errorType: ErrorTypes.NOT_FOUND,
+        },
+        done,
+      );
+    });
+
+    it('should reject requests when the requested project is not active', (done) => {
+      apiRoute = `/projects/${inactiveProject.id}/permissions`;
+      request(serverUrl).get(apiRoute).set('x-auth-token', adminAuthToken).expect(
+        404,
+        {
+          error: 'requested project not found',
+          errorType: ErrorTypes.NOT_FOUND,
+        },
+        done,
+      );
+    });
+
+    it('should successfully return admin permissions', (done) => {
+      request(serverUrl)
+        .get(apiRoute)
+        .set('x-auth-token', adminAuthToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, permissions } = res.body;
+          expect(message).toBe('project permissions successfully retrieved');
+          expect(permissions).toEqual({
+            canRemoveProject: true,
+            canUpdateProject: true,
+            canCreateAdminMembership: true,
+            canCreateMembership: true,
+            canUpdateAdminMembership: true,
+            canUpdateMembership: true,
+            canRemoveAdminMembership: true,
+            canRemoveMembership: true,
+            canCreateStatus: true,
+            canUpdateStatus: true,
+            canRemoveStatus: true,
+            canCreateStory: true,
+            canUpdateStory: true,
+            canRemoveStory: true,
+            canReadStory: true,
+          });
+          done();
+        });
+    });
+
+    it('should successfully return manager permissions', (done) => {
+      request(serverUrl)
+        .get(apiRoute)
+        .set('x-auth-token', managerAuthToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, permissions } = res.body;
+          expect(message).toBe('project permissions successfully retrieved');
+          expect(permissions).toEqual({
+            canRemoveProject: false,
+            canUpdateProject: true,
+            canCreateAdminMembership: false,
+            canCreateMembership: true,
+            canUpdateAdminMembership: false,
+            canUpdateMembership: true,
+            canRemoveAdminMembership: false,
+            canRemoveMembership: true,
+            canCreateStatus: true,
+            canUpdateStatus: true,
+            canRemoveStatus: true,
+            canCreateStory: true,
+            canUpdateStory: true,
+            canRemoveStory: true,
+            canReadStory: true,
+          });
+          done();
+        });
+    });
+
+    it('should successfully return developer permissions', (done) => {
+      request(serverUrl)
+        .get(apiRoute)
+        .set('x-auth-token', developerAuthToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, permissions } = res.body;
+          expect(message).toBe('project permissions successfully retrieved');
+          expect(permissions).toEqual({
+            canRemoveProject: false,
+            canUpdateProject: false,
+            canCreateAdminMembership: false,
+            canCreateMembership: false,
+            canUpdateAdminMembership: false,
+            canUpdateMembership: false,
+            canRemoveAdminMembership: false,
+            canRemoveMembership: false,
+            canCreateStatus: false,
+            canUpdateStatus: false,
+            canRemoveStatus: false,
+            canCreateStory: true,
+            canUpdateStory: true,
+            canRemoveStory: true,
+            canReadStory: true,
+          });
+          done();
+        });
+    });
+
+    it('should successfully return viewer permissions', (done) => {
+      request(serverUrl)
+        .get(apiRoute)
+        .set('x-auth-token', viewerAuthToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, permissions } = res.body;
+          expect(message).toBe('project permissions successfully retrieved');
+          expect(permissions).toEqual({
+            canRemoveProject: false,
+            canUpdateProject: false,
+            canCreateAdminMembership: false,
+            canCreateMembership: false,
+            canUpdateAdminMembership: false,
+            canUpdateMembership: false,
+            canRemoveAdminMembership: false,
+            canRemoveMembership: false,
+            canCreateStatus: false,
+            canUpdateStatus: false,
+            canRemoveStatus: false,
+            canCreateStory: false,
+            canUpdateStory: false,
+            canRemoveStory: false,
+            canReadStory: true,
+          });
+          done();
+        });
+    });
+
+    it('should successfully return non-member permissions', (done) => {
+      request(serverUrl)
+        .get(apiRoute)
+        .set('x-auth-token', nonMemberAuthToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, permissions } = res.body;
+          expect(message).toBe('project permissions successfully retrieved');
+          expect(permissions).toEqual({
+            canRemoveProject: false,
+            canUpdateProject: false,
+            canCreateAdminMembership: false,
+            canCreateMembership: false,
+            canUpdateAdminMembership: false,
+            canUpdateMembership: false,
+            canRemoveAdminMembership: false,
+            canRemoveMembership: false,
+            canCreateStatus: false,
+            canUpdateStatus: false,
+            canRemoveStatus: false,
+            canCreateStory: false,
+            canUpdateStory: false,
+            canRemoveStory: false,
+            canReadStory: false,
+          });
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new endpoint `/projects/:projectId/permissions` that will returns booleans that indicate what actions the authenticated user can take for the project.

This was made for the UI (whenever I make it in like 200 years lol) so that an authenticated user has an explicit set of permissions on what actions they can take, instead of inferring that based on their project membership data.