### PR TITLE
`Feature` Refresh Token

### DIFF
--- a/src/controllers/auth/generateToken/generateToken.ts
+++ b/src/controllers/auth/generateToken/generateToken.ts
@@ -1,8 +1,7 @@
-import jwt from 'jsonwebtoken';
 import { User } from 'src/models';
-import { SECRET } from 'src/config/auth';
 import { AuthenticationError } from 'src/server/utils/errors';
 import { UserData } from 'src/server/types';
+import signJwtToken from 'src/controllers/auth/utils/signJwtToken';
 
 interface UserDataWithToken extends UserData {
   token: string;
@@ -26,13 +25,7 @@ const generateToken: GenerateToken = async (username, password) => {
     throw new AuthenticationError('username and password combination is invalid');
   }
 
-  const tokenData = {
-    id: user.id,
-    apiKey: user.apiKey,
-  };
-
-  const jwtOptions = { expiresIn: '10h' };
-  const token = jwt.sign(tokenData, SECRET, jwtOptions);
+  const token = signJwtToken(user);
 
   return {
     token,

--- a/src/controllers/auth/getAuthenticationDetails/index.ts
+++ b/src/controllers/auth/getAuthenticationDetails/index.ts
@@ -1,7 +1,12 @@
 import { Request, Response } from 'express';
+import signJwtToken from 'src/controllers/auth/utils/signJwtToken';
 
 const getAuthenticationDetails = (req: Request, res: Response) => {
   const { username, displayName, createdOn, updatedOn } = req.user;
+
+  const refreshedToken = signJwtToken(req.user);
+
+  res.set('x-auth-token', refreshedToken);
   return res.success('user successfully authenticated via token', {
     user: {
       username,

--- a/src/controllers/auth/utils/signJwtToken.ts
+++ b/src/controllers/auth/utils/signJwtToken.ts
@@ -1,0 +1,19 @@
+import jwt from 'jsonwebtoken';
+import { User } from 'src/models';
+import { SECRET } from 'src/config/auth';
+
+type SignJwtToken = (user: User) => string;
+
+const signJwtToken: SignJwtToken = (user) => {
+  const tokenData = {
+    id: user.id,
+    apiKey: user.apiKey,
+  };
+
+  const jwtOptions = { expiresIn: '10h' };
+  const token = jwt.sign(tokenData, SECRET, jwtOptions);
+
+  return token;
+};
+
+export default signJwtToken;

--- a/test/auth/authenticateToken.test.ts
+++ b/test/auth/authenticateToken.test.ts
@@ -136,7 +136,7 @@ describe('Authenticate AuthToken', () => {
       );
     });
 
-    it('should successfully authenticate a token', (done) => {
+    it('should successfully authenticate a token and send a refresh token', (done) => {
       const jwtToken = testHelper.generateToken(testUser);
       request(serverUrl)
         .get(apiRoute)
@@ -155,6 +155,11 @@ describe('Authenticate AuthToken', () => {
             createdOn: testUser.createdOn.toISOString(),
             updatedOn: null,
           });
+
+          // This endpoint should return a fresh auth token as well.
+          const refreshToken = res.headers['x-auth-token'];
+          expect(refreshToken).toBeTruthy();
+          expect(refreshToken).not.toBe(jwtToken);
           done();
         });
     });


### PR DESCRIPTION
This PR updates the existing `/auth/token` route which really didn't have much of a purpose beyond unit testing that token authentication works perfectly.

Now this route will generate a new authToken and send it back with the response. The UI can now utilize this route to perform a token refresh so that users shouldn't need to reauthenticate once their token expires.

I created a reusable util method called `signJwtToken` that is used in both places that we generate authTokens so that things remain consistent.