### PR TITLE
`Feature` Dashboard Projects

### DIFF
--- a/src/controllers/dashboard/getUserProjects/getUserProjects.ts
+++ b/src/controllers/dashboard/getUserProjects/getUserProjects.ts
@@ -1,0 +1,59 @@
+import { Project, User } from 'src/models';
+import { DashboardProjectData } from 'src/server/types';
+import { PaginationData } from 'src/controllers/validationUtils';
+
+type GetUserProjects = (
+  user: User,
+  paginationData: PaginationData,
+) => Promise<DashboardProjectData[]>;
+
+const getUserProjects: GetUserProjects = async (user, paginationData) => {
+  const { itemsPerPage, pageOffset } = paginationData;
+  const membershipProjects = await user.getMemberships({
+    limit: itemsPerPage,
+    offset: pageOffset,
+    order: [['createdOn', 'ASC']],
+    include: [
+      {
+        model: Project,
+        where: { isActive: true },
+        as: 'project',
+        required: true,
+        include: [{ model: User, as: 'createdBy', where: { isActive: true } }],
+      },
+    ],
+  });
+
+  return membershipProjects.map(
+    ({ project, isProjectAdmin, isProjectManager, isProjectDeveloper }) => {
+      let role: DashboardProjectData['role'];
+      if (isProjectAdmin) {
+        role = 'Admin';
+      } else if (isProjectManager) {
+        role = 'Manager';
+      } else if (isProjectDeveloper) {
+        role = 'Developer';
+      } else {
+        role = 'Viewer';
+      }
+
+      return {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        createdOn: project.createdOn,
+        updatedOn: project.updatedOn,
+        createdBy:
+          project.createdById && project.createdBy ?
+            {
+              username: project.createdBy.username,
+              displayName: project.createdBy.displayName,
+            }
+          : null,
+        role,
+      };
+    },
+  );
+};
+
+export default getUserProjects;

--- a/src/controllers/dashboard/getUserProjects/getUserProjects.ts
+++ b/src/controllers/dashboard/getUserProjects/getUserProjects.ts
@@ -12,7 +12,7 @@ const getUserProjects: GetUserProjects = async (user, paginationData) => {
   const membershipProjects = await user.getMemberships({
     limit: itemsPerPage,
     offset: pageOffset,
-    order: [['createdOn', 'ASC']],
+    order: [['createdOn', 'DESC']],
     include: [
       {
         model: Project,

--- a/src/controllers/dashboard/getUserProjects/getUserProjectsValidation.ts
+++ b/src/controllers/dashboard/getUserProjects/getUserProjectsValidation.ts
@@ -1,6 +1,7 @@
 import { Request } from 'express';
 import { User, Membership, Project } from 'src/models';
 import { validatePagination, PaginationData } from 'src/controllers/validationUtils';
+import Sequelize, { WhereOptions } from 'sequelize';
 
 type GetUserProjectsValidation = (
   user: User,
@@ -11,10 +12,25 @@ const getUserProjectsValidation: GetUserProjectsValidation = async (
   user,
   queryString,
 ) => {
+  const nameFilter = queryString.nameFilter;
+  const projectWhereOptions: WhereOptions = {
+    isActive: true,
+  };
+  if (nameFilter) {
+    projectWhereOptions.name = {
+      [Sequelize.Op.iLike]: `%${nameFilter}%`,
+    };
+  }
+
   const membershipCount = await Membership.count({
     include: [
       { model: User, where: { id: user.id }, as: 'user', required: true },
-      { model: Project, where: { isActive: true }, as: 'project', required: true },
+      {
+        model: Project,
+        where: projectWhereOptions,
+        as: 'project',
+        required: true,
+      },
     ],
   });
   return validatePagination(queryString, membershipCount);

--- a/src/controllers/dashboard/getUserProjects/getUserProjectsValidation.ts
+++ b/src/controllers/dashboard/getUserProjects/getUserProjectsValidation.ts
@@ -1,0 +1,23 @@
+import { Request } from 'express';
+import { User, Membership, Project } from 'src/models';
+import { validatePagination, PaginationData } from 'src/controllers/validationUtils';
+
+type GetUserProjectsValidation = (
+  user: User,
+  queryString: Request['query'],
+) => Promise<PaginationData>;
+
+const getUserProjectsValidation: GetUserProjectsValidation = async (
+  user,
+  queryString,
+) => {
+  const membershipCount = await Membership.count({
+    include: [
+      { model: User, where: { id: user.id }, as: 'user', required: true },
+      { model: Project, where: { isActive: true }, as: 'project', required: true },
+    ],
+  });
+  return validatePagination(queryString, membershipCount);
+};
+
+export default getUserProjectsValidation;

--- a/src/controllers/dashboard/getUserProjects/index.ts
+++ b/src/controllers/dashboard/getUserProjects/index.ts
@@ -5,7 +5,7 @@ import getUserProjects from './getUserProjects';
 const getUserProjectsFlow = async (req: Request, res: Response) => {
   const user = req.user;
   const paginationData = await getUserProjectsValidation(user, req.query);
-  const projects = await getUserProjects(user, paginationData);
+  const projects = await getUserProjects(user, paginationData, req.query);
 
   return res.success('dashboard projects have been successfully retrieved', {
     page: paginationData.page,

--- a/src/controllers/dashboard/getUserProjects/index.ts
+++ b/src/controllers/dashboard/getUserProjects/index.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from 'express';
+import getUserProjectsValidation from './getUserProjectsValidation';
+import getUserProjects from './getUserProjects';
+
+const getUserProjectsFlow = async (req: Request, res: Response) => {
+  const user = req.user;
+  const paginationData = await getUserProjectsValidation(user, req.query);
+  const projects = await getUserProjects(user, paginationData);
+
+  return res.success('dashboard projects have been successfully retrieved', {
+    page: paginationData.page,
+    totalItems: paginationData.totalItems,
+    totalPages: paginationData.totalPages,
+    itemsPerPage: paginationData.itemsPerPage,
+    projects,
+  });
+};
+
+export default getUserProjectsFlow;

--- a/src/controllers/dashboard/index.ts
+++ b/src/controllers/dashboard/index.ts
@@ -1,0 +1,5 @@
+import { default as getUserProjects } from './getUserProjects';
+
+export default {
+  getUserProjects,
+};

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -4,3 +4,4 @@ export { default as ProjectController } from './project';
 export { default as MembershipController } from './membership';
 export { default as StatusController } from './status';
 export { default as StoryController } from './story';
+export { default as DashboardController } from './dashboard';

--- a/src/models/project/project.ts
+++ b/src/models/project/project.ts
@@ -83,7 +83,7 @@ export const initializeProject = (sequelize: Sequelize) => {
         type: DataTypes.STRING,
       },
       description: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
       },
       createdOn: {
         type: DataTypes.DATE,

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { AuthController, DashboardController } from 'src/controllers';
+
+const configureDashboardRoutes = (router: Router) => {
+  router
+    .route('/dashboard/projects')
+    .all(AuthController.authenticateToken)
+    .get(DashboardController.getUserProjects);
+};
+
+export default configureDashboardRoutes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,3 +5,4 @@ export { default as configureProjectRoutes } from './project';
 export { default as configureMembershipRoutes } from './membership';
 export { default as configureStatusRoutes } from './status';
 export { default as configureStoryRoutes } from './story';
+export { default as configureDashboardRoutes } from './dashboard';

--- a/src/server/types/index.ts
+++ b/src/server/types/index.ts
@@ -18,6 +18,10 @@ export interface ProjectData {
   deletedBy?: Pick<UserData, 'username' | 'displayName'> | null;
 }
 
+export interface DashboardProjectData extends ProjectData {
+  role: 'Admin' | 'Manager' | 'Developer' | 'Viewer';
+}
+
 export enum AuthorizationAction {
   CREATE = 'create',
   READ = 'read',

--- a/src/server/utils/configureRoutes.ts
+++ b/src/server/utils/configureRoutes.ts
@@ -7,6 +7,7 @@ import {
   configureMembershipRoutes,
   configureStatusRoutes,
   configureStoryRoutes,
+  configureDashboardRoutes,
 } from 'src/routes';
 
 const configureRoutes = (app: Express) => {
@@ -18,6 +19,7 @@ const configureRoutes = (app: Express) => {
   configureMembershipRoutes(router);
   configureStatusRoutes(router);
   configureStoryRoutes(router);
+  configureDashboardRoutes(router);
   configureCatchAllRoute(router); // This catch-all route must always be last.
 
   app.use(router);

--- a/test/dashboard/getUserProjects.test.ts
+++ b/test/dashboard/getUserProjects.test.ts
@@ -1,0 +1,208 @@
+import { TestHelper } from '../utils';
+import { ErrorTypes } from '../../src/server/utils/errors';
+import request from 'supertest';
+import { User, Project } from '../../src/models';
+const testHelper = new TestHelper();
+const serverUrl = testHelper.getServerUrl();
+const apiRoute = '/dashboard/projects';
+
+describe('Dashboard GetUserProjects', () => {
+  describe(`GET ${apiRoute}`, () => {
+    let authenticatedUser: User;
+    let testUser1: User;
+    let testUser2: User;
+    let sampleProject1: Project;
+    let sampleProject2: Project;
+    let sampleProject3: Project;
+    let sampleProject4: Project;
+    let inactiveProject: Project;
+    let authToken: string;
+
+    beforeAll(async () => {
+      authenticatedUser = await testHelper.createTestUser();
+      testUser1 = await testHelper.createTestUser();
+      testUser2 = await testHelper.createTestUser();
+
+      sampleProject4 = await testHelper.createTestProject(
+        authenticatedUser,
+        'test project alpha',
+        'project1 was generated via automated testing.',
+      );
+      await testHelper.createTestProject(
+        testUser2,
+        'test project beta',
+        'project2 was generated via automated testing.',
+      );
+      await testHelper.createTestProject(
+        testUser1,
+        'test project charlie',
+        'project3 was generated via automated testing.',
+      );
+      sampleProject3 = await testHelper.createTestProject(
+        authenticatedUser,
+        'test project delta',
+        'project4 was generated via automated testing.',
+      );
+      sampleProject2 = await testHelper.createTestProject(
+        testUser1,
+        'test project echo',
+        'project5 was generated via automated testing.',
+      );
+      sampleProject1 = await testHelper.createTestProject(
+        testUser2,
+        'test project foxtrot',
+        'project6 was generated via automated testing.',
+      );
+
+      sampleProject1.updatedById = testUser2.id;
+      sampleProject1.updatedOn = new Date();
+      await sampleProject1.save();
+
+      inactiveProject = await testHelper.createTestProject(
+        authenticatedUser,
+        'test project inactive',
+        'generated via automated testing',
+      );
+      inactiveProject.isActive = false;
+      inactiveProject.deletedOn = new Date();
+      inactiveProject.deletedById = authenticatedUser.id;
+      await inactiveProject.save();
+
+      await sampleProject2.createMembership({
+        userId: authenticatedUser.id,
+        isProjectDeveloper: true,
+      });
+
+      await sampleProject1.createMembership({
+        userId: authenticatedUser.id,
+      });
+
+      authToken = testHelper.generateToken(authenticatedUser);
+    });
+
+    afterAll(async () => {
+      await testHelper.removeTestData();
+    });
+
+    it('should reject requests when x-auth-token is missing', (done) => {
+      request(serverUrl).get(apiRoute).expect(
+        400,
+        {
+          error: 'x-auth-token header is missing from input',
+          errorType: ErrorTypes.VALIDATION,
+        },
+        done,
+      );
+    });
+
+    it('should successfully return a list of active projects that the authenticated user is a member of', (done) => {
+      request(serverUrl)
+        .get(`${apiRoute}?itemsPerPage=5&page=1`)
+        .set('x-auth-token', authToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, ...projectListData } = res.body;
+          expect(message).toBe('dashboard projects have been successfully retrieved');
+          expect(projectListData).toEqual({
+            page: 1,
+            itemsPerPage: 5,
+            totalPages: 1,
+            totalItems: 4,
+            projects: [
+              {
+                id: sampleProject1.id,
+                name: sampleProject1.name,
+                description: sampleProject1.description,
+                createdOn: sampleProject1.createdOn.toISOString(),
+                createdBy: {
+                  username: testUser2.username,
+                  displayName: testUser2.displayName,
+                },
+                updatedOn: sampleProject1.updatedOn?.toISOString(),
+                role: 'Viewer',
+              },
+              {
+                id: sampleProject2.id,
+                name: sampleProject2.name,
+                description: sampleProject2.description,
+                createdOn: sampleProject2.createdOn.toISOString(),
+                createdBy: {
+                  username: testUser1.username,
+                  displayName: testUser1.displayName,
+                },
+                updatedOn: null,
+                role: 'Developer',
+              },
+              {
+                id: sampleProject3.id,
+                name: sampleProject3.name,
+                description: sampleProject3.description,
+                createdOn: sampleProject3.createdOn.toISOString(),
+                createdBy: {
+                  username: authenticatedUser.username,
+                  displayName: authenticatedUser.displayName,
+                },
+                updatedOn: null,
+                role: 'Admin',
+              },
+              {
+                id: sampleProject4.id,
+                name: sampleProject4.name,
+                description: sampleProject4.description,
+                createdOn: sampleProject4.createdOn.toISOString(),
+                createdBy: {
+                  username: authenticatedUser.username,
+                  displayName: authenticatedUser.displayName,
+                },
+                updatedOn: null,
+                role: 'Admin',
+              },
+            ],
+          });
+
+          done();
+        });
+    });
+
+    it('should successfully filter projects by name', (done) => {
+      request(serverUrl)
+        .get(`${apiRoute}?nameFilter=echo`)
+        .set('x-auth-token', authToken)
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const { message, ...projectListData } = res.body;
+          expect(message).toBe('dashboard projects have been successfully retrieved');
+          expect(projectListData).toEqual({
+            page: 1,
+            itemsPerPage: 10,
+            totalPages: 1,
+            totalItems: 1,
+            projects: [
+              {
+                id: sampleProject2.id,
+                name: sampleProject2.name,
+                description: sampleProject2.description,
+                createdOn: sampleProject2.createdOn.toISOString(),
+                createdBy: {
+                  username: testUser1.username,
+                  displayName: testUser1.displayName,
+                },
+                updatedOn: null,
+                role: 'Developer',
+              },
+            ],
+          });
+
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new route `GET /dashboard/projects` which allows users to retrieve a paginated list of active projects that they have a membership with.

Additionally, this implements a way to filter projects by name using the `nameFilter` querystring.